### PR TITLE
Fixing image/png instead of images/png

### DIFF
--- a/bot/plugins/download.py
+++ b/bot/plugins/download.py
@@ -58,7 +58,7 @@ def _telegram_file(client, message):
     file = message.audio
   elif message.photo:
   	file = message.photo
-  	file.mime_type = "images/png"
+  	file.mime_type = "image/png"
   	file.file_name = f"IMG-{user_id}-{message.message_id}.png"
   sent_message.edit(Messages.DOWNLOAD_TG_FILE.format(file.file_name, humanbytes(file.file_size), file.mime_type))
   LOGGER.info(f'Download:{user_id}: {file.file_id}')


### PR DESCRIPTION
changing mime from (file.mime_type = "images/png")   which gives Type Unknown File on Google Drive, no thumbnail and only viewable if downloaded

to 	file.mime_type = "image/png" to fix Type Image viewable and recognized by both GDrive and downloads, thumbnail works.

//Google API V3 Documentation : https://developers.google.com/drive/api/v3/manage-uploads#python